### PR TITLE
Fix typo for TK_DEFINE comments

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -110,8 +110,8 @@ typedef enum {
     TK_TRUE,     // true
     TK_FALSE,    // false
     TK_BOOL,     // bool
-    TK_DEFINE,  // #dfined
-    TK_DEFINE_END,  // #dfined end
+    TK_DEFINE,  // #defined
+    TK_DEFINE_END,  // #defined end
     TK_EXCLAMT, // !
 } TokenKind;
 


### PR DESCRIPTION
## Summary
- correct 'dfined' to 'defined' in TK_DEFINE and TK_DEFINE_END comments

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685fb9414bb4832d841254286cb97de3