### PR TITLE
Add self-hosting script for 9cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 https://www.sigbus.info/compilerbook
+
+## Self-hosting 9cc
+
+First build the compiler using the system toolchain:
+
+```bash
+make
+```
+
+This produces an executable named `9cc`. You can then compile the
+compiler with itself using the `selfhost.sh` script:
+
+```bash
+./selfhost.sh
+```
+
+The script invokes `./9cc` for every `*.c` file to generate assembly,
+assembles each file with `cc -c` and links the resulting objects into
+`9cc-self`. The resulting `9cc-self` is a self-hosted build of the
+compiler.

--- a/selfhost.sh
+++ b/selfhost.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Compile each C file in the repository using the existing 9cc
+for c in *.c; do
+    ./9cc "$c" > "${c%.c}.s"
+done
+
+# Assemble assembly files
+for s in *.s; do
+    cc -c "$s"
+done
+
+# Link object files into a self-hosted compiler
+cc -o 9cc-self *.o
+
+echo "Self-hosted compiler generated as ./9cc-self"


### PR DESCRIPTION
## Summary
- add a `selfhost.sh` script that compiles 9cc with itself
- document how to use the script in `README.md`

## Testing
- `make clean && make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ff13d492c832d994fedf2f3232ee8