### PR TITLE
Add typedef struct alias support

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -147,6 +147,16 @@ struct EnumDef {
     EnumDef *next;
 };
 
+typedef struct StructAlias StructAlias;
+
+struct StructAlias {
+    char *tag;
+    int tag_len;
+    char *alias;
+    int alias_len;
+    StructAlias *next;
+};
+
 void tokenize(char *p);
 Node *stmt();
 Node *assign();
@@ -189,6 +199,7 @@ GVar *globals;
 GVar *literals;
 Node *defined_structs;
 EnumDef *defined_enums;
+StructAlias *struct_aliases;
 
 LVar *find_lvar(Token *tok);
 GVar *find_gvar(Token *tok);

--- a/container.c
+++ b/container.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 #include "9cc.h"
 
 LVar *find_lvar(Token *tok) {
@@ -30,6 +31,20 @@ Node *find_defined_structs(Token *tok) {
     for (Node *var = defined_structs; var; var = var->child) {
         if (var->namelen == tok->len && !memcmp(tok->str, var->name, var->namelen))
             return var;
+    }
+    for (StructAlias *al = struct_aliases; al; al = al->next) {
+        if ((al->tag_len == tok->len && !memcmp(tok->str, al->tag, al->tag_len)) ||
+            (al->alias_len == tok->len && !memcmp(tok->str, al->alias, al->alias_len))) {
+            for (Node *var = defined_structs; var; var = var->child) {
+                if (var->namelen == al->tag_len && !memcmp(al->tag, var->name, al->tag_len))
+                    return var;
+            }
+            Node *node = calloc(1, sizeof(Node));
+            node->kind = ND_STRUCTDEF;
+            node->name = al->tag;
+            node->namelen = al->tag_len;
+            return node;
+        }
     }
     return NULL;
 }

--- a/parser.c
+++ b/parser.c
@@ -408,6 +408,23 @@ Node *define_function_or_gvar() {
         if (consume_kind(TK_ENUM)) {
             defined_enum();
             return calloc(1, sizeof(Node));
+        } else if (consume_kind(TK_STRUCT)) {
+            Token *tag = consume_indent();
+            if (!(token->kind == TK_RESERVED && token->len == 1 && *token->str == '{')) {
+                Token *alias = consume_indent();
+                expect(";");
+                StructAlias *al = calloc(1, sizeof(StructAlias));
+                al->tag = tag->str;
+                al->tag_len = tag->len;
+                al->alias = alias->str;
+                al->alias_len = alias->len;
+                al->next = struct_aliases;
+                struct_aliases = al;
+                return calloc(1, sizeof(Node));
+            } else {
+                // Currently we do not support typedef with struct body
+                // fall through to normal processing
+            }
         }
     }
     Type *top = calloc(1, sizeof(Type));

--- a/test.sh
+++ b/test.sh
@@ -222,6 +222,7 @@ assert 2 'test_file/preprocessor/testb.c'
 assert 45 'test_file/preprocessor/testc.c'
 assert 42 'test_file/preprocessor/testd.c'
 assert 200 'test_file/preprocessor/teste.c'
+assert 0 'test_file/typedef/testaa.c'
 
 echo OK
 

--- a/test_file/typedef/testaa.c
+++ b/test_file/typedef/testaa.c
@@ -1,0 +1,6 @@
+typedef struct Type Type;
+typedef struct LVar LVar;
+typedef struct Node Node;
+typedef struct GVar GVar;
+typedef struct EnumDef EnumDef;
+int main(){return 0;}


### PR DESCRIPTION
## Summary
- parse `typedef struct <Tag> <Alias>;` forward declarations
- store struct alias info for lookup
- update container search logic
- add regression test for parsing forward declarations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ff13d0f74832d827bd83285611fc1